### PR TITLE
Add config file loader

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -49,3 +49,42 @@ WINDOW_TYPE = "hamming"
 WINDOW_NORM = "power"
 
 # Other global options can be added here as needed
+
+
+def load_config(config_path):
+    """Load a JSON or YAML configuration file and override defaults.
+
+    Parameters
+    ----------
+    config_path : str
+        Path to the configuration file. Supported formats are JSON
+        and YAML (requires ``PyYAML``).
+    """
+
+    if not os.path.isfile(config_path):
+        raise FileNotFoundError(f"Config file '{config_path}' not found")
+
+    _, ext = os.path.splitext(config_path)
+    ext = ext.lower()
+
+    with open(config_path, "r") as f:
+        if ext in {".yml", ".yaml"}:
+            try:
+                import yaml
+            except Exception as exc:  # pragma: no cover - import error path
+                raise ImportError(
+                    "PyYAML must be installed to read YAML configuration files"
+                ) from exc
+            config = yaml.safe_load(f)
+        else:
+            config = json.load(f)
+
+    if not isinstance(config, dict):
+        raise ValueError("Configuration file must define a dictionary")
+
+    # Update any matching globals using upper-case keys
+    for key, value in config.items():
+        key_upper = key.upper()
+        if key_upper in globals():
+            globals()[key_upper] = value
+

--- a/pod.py
+++ b/pod.py
@@ -15,6 +15,7 @@ Reference codes:
 # Standard library imports
 import os
 import time
+import argparse
 
 import h5py
 import matplotlib.pyplot as plt
@@ -773,10 +774,18 @@ class PODAnalyzer(BaseAnalyzer):
 
 # Example usage when the script is run directly
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run POD analysis")
+    parser.add_argument("--config", help="Path to JSON/YAML configuration file", default=None)
+    args = parser.parse_args()
+
+    if args.config:
+        from configs import load_config
+        load_config(args.config)
+
     # --- Configuration ---
-    # data_file = "./data/jetLES_small.mat" # Updated data path
+    # data_file = "./data/jetLES_small.mat"  # Updated data path
     data_file = "./data/jetLES.mat"  # Path to your data file
-    # data_file = "./data/cavityPIV.mat" # Path to your data file
+    # data_file = "./data/cavityPIV.mat"  # Path to your data file
 
     n_modes_to_save_main = 10  # Number of POD modes to save
     n_modes_to_plot_spatial_main = 4  # Number of spatial modes to visualize

--- a/spod.py
+++ b/spod.py
@@ -3,6 +3,7 @@ import glob
 import json
 import os
 import time
+import argparse
 
 import h5py
 import matplotlib.colors as colors
@@ -435,10 +436,18 @@ class SPODAnalyzer(BaseAnalyzer):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run SPOD analysis")
+    parser.add_argument("--config", help="Path to JSON/YAML configuration file", default=None)
+    args = parser.parse_args()
+
+    if args.config:
+        from configs import load_config
+        load_config(args.config)
+
     # --- Configuration ---
-    # data_file = "./data/jetLES_small.mat" # Updated data path
+    # data_file = "./data/jetLES_small.mat"  # Updated data path
     data_file = "./data/jetLES.mat"  # Path to your data file
-    # data_file = "./data/cavityPIV.mat" # Path to your data file
+    # data_file = "./data/cavityPIV.mat"  # Path to your data file
 
     # Default parameters
     nfft_param = 128  # FFT block size


### PR DESCRIPTION
## Summary
- add `load_config` to `configs.py` for reading JSON/YAML files
- allow POD and SPOD scripts to override defaults via `--config` command line option

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68402b80e98c832c8434abeb4674090b