### PR TITLE
Fix repository name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ A **pure-Python** collection of simple scripts (no MPI, minimal dependencies) fo
 ## 💾 Getting the Code
 
 ```bash
-git clone https://github.com/ricardofrantz/tri-modal-decomp.git
-cd tri-modal-decomp
+git clone https://github.com/ricardofrantz/modal-decomp.git
+cd modal-decomp
 ```
 
 ## Running Tests


### PR DESCRIPTION
## Summary
- update repo path in the README instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68404798339c832cb7905cd1536ac2fb