### PR TITLE
Add threads support and SPOD mode plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pytest
 
 ### Parallel Execution
 
-Set the environment variable `OMP_NUM_THREADS` to control how many worker threads
+Set the environment variable `OMP_NUM_THREADS` to control how many threads
 are used for FFT and SPOD computations. If the variable is unset or invalid,
 all detected CPU cores are used by default:
 

--- a/bmsd.py
+++ b/bmsd.py
@@ -32,6 +32,7 @@ import matplotlib.pyplot as plt
 # Third-party imports
 import numpy as np
 import scipy.linalg as eig
+from tqdm import tqdm
 
 from configs import (
     FIGURES_DIR_BSMD,
@@ -48,7 +49,7 @@ from utils import (
     load_mat_data,  # If used in __main__
     make_result_filename,  # For saving results
     print_summary,
-    get_num_workers,  # For detecting available CPU threads
+    get_num_threads,  # For detecting available CPU threads
 )
 
 
@@ -373,7 +374,9 @@ class BSMDAnalyzer(BaseAnalyzer):
             print("Error: Frequency/Strouhal information not available. Cannot map triads.")
             return
 
-        for i, (st_alpha_target, st_beta_target, st_gamma_target) in enumerate(self.static_triads_list):
+        for i, (st_alpha_target, st_beta_target, st_gamma_target) in enumerate(
+            tqdm(self.static_triads_list, desc="BSMD Triads")
+        ):
             idx_alpha = find_closest_freq_idx(self.St, st_alpha_target)
             idx_beta = find_closest_freq_idx(self.St, st_beta_target)
             idx_gamma = find_closest_freq_idx(self.St, st_gamma_target)
@@ -513,7 +516,7 @@ if __name__ == "__main__":
     parser.add_argument("--plot", action="store_true", help="Generate example plots")
     args = parser.parse_args()
 
-    threads_available = get_num_workers()
+    threads_available = get_num_threads()
     print(f"Available CPU threads detected: {threads_available}")
     if os.environ.get("OMP_NUM_THREADS") is None:
         print("Set OMP_NUM_THREADS to this value for maximum performance.")

--- a/spod.py
+++ b/spod.py
@@ -33,7 +33,7 @@ from utils import (
     print_summary,
     spod_function,  # Core SPOD routine for SPODAnalyzer
     parallel_map,  # For parallel processing of SPOD modes
-    get_num_workers,  # Utility to get number of available CPU threads
+    get_num_threads,  # Utility to get number of available CPU threads
 )
 
 
@@ -90,7 +90,7 @@ class SPODAnalyzer(BaseAnalyzer):
         window_type=WINDOW_TYPE,
         data_loader=None,
         spatial_weight_type="auto",
-        n_workers=None,
+        n_threads=None,
     ):
         """
         Initializes the SPODAnalyzer instance.
@@ -127,7 +127,7 @@ class SPODAnalyzer(BaseAnalyzer):
             figures_dir=figures_dir,
             data_loader=data_loader,
             spatial_weight_type=spatial_weight_type,
-            n_workers=n_workers,
+            n_threads=n_threads,
         )
 
         self._validate_inputs()
@@ -266,8 +266,8 @@ class SPODAnalyzer(BaseAnalyzer):
             )
             return i, phi_freq, lambda_freq, psi_freq
 
-        if self.n_workers > 1:
-            results = parallel_map(compute_freq, range(n_freq_bins_from_qhat), workers=self.n_workers)
+        if self.n_threads > 1:
+            results = parallel_map(compute_freq, range(n_freq_bins_from_qhat), threads=self.n_threads)
             for i, phi_freq, lambda_freq, psi_freq in results:
                 self.modes[i, :, :] = phi_freq
                 self.eigenvalues[i, :] = lambda_freq
@@ -602,7 +602,7 @@ if __name__ == "__main__":
     parser.add_argument("--plot", action="store_true", help="Generate default plots")
     args = parser.parse_args()
 
-    threads_available = get_num_workers()
+    threads_available = get_num_threads()
     print(f"Available CPU threads detected: {threads_available}")
     if os.environ.get("OMP_NUM_THREADS") is None:
         print("Set OMP_NUM_THREADS to this value for maximum performance.")
@@ -695,6 +695,7 @@ if __name__ == "__main__":
             print("No SPOD results to plot. Run with --compute first.")
         else:
             analyzer.plot_eigenvalues_v2()
+            analyzer.plot_modes()
 
     if run_all:
         print_summary("SPOD", analyzer.results_dir, analyzer.figures_dir)

--- a/tests/test_blocksfft.py
+++ b/tests/test_blocksfft.py
@@ -4,7 +4,7 @@ from utils import blocksfft
 
 def test_blocksfft_constant_signal():
     q = np.ones((4, 2))
-    result = blocksfft(q, nfft=4, nblocks=1, novlap=0, n_workers=2)
+    result = blocksfft(q, nfft=4, nblocks=1, novlap=0, n_threads=2)
     assert result.shape == (4 // 2 + 1, 2, 1)
     assert np.allclose(result, 0)
 


### PR DESCRIPTION
## Summary
- rename worker nomenclature to thread
- show FFT backend in logs
- add SPOD eigenmode plots by default
- display BSMD progress via tqdm

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404c67ac64832c9972bdac16fa4200